### PR TITLE
Avoid crashing on null references

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -52,13 +52,22 @@ namespace AnalyzeDotNetProject
         private static void ReportDependency(LockFileTargetLibrary projectLibrary, LockFileTarget lockFileTargetFramework, int indentLevel)
         {
             Console.Write(new String(' ', indentLevel * 2));
+            if (projectLibrary == null) {
+              Console.WriteLine("projectLibrary is <null>");
+              return;
+            }
             Console.WriteLine($"{projectLibrary.Name}, v{projectLibrary.Version}");
 
             foreach (var childDependency in projectLibrary.Dependencies)
             {
                 var childLibrary = lockFileTargetFramework.Libraries.FirstOrDefault(library => library.Name == childDependency.Id);
 
-                ReportDependency(childLibrary, lockFileTargetFramework, indentLevel + 1);
+                if (childLibrary != null) {
+                  ReportDependency(childLibrary, lockFileTargetFramework, indentLevel + 1);
+                } else {
+                  Console.Write(new String(' ', (indentLevel+1*2)));
+                  Console.WriteLine($"Could not find a childLibrary for {childDependency.Id} in: {String.Join(",", lockFileTargetFramework.Libraries.Select(l => l.Name))}");
+                }
             }
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using NuGet.ProjectModel;
 
@@ -9,7 +10,15 @@ namespace AnalyzeDotNetProject
         static void Main(string[] args)
         {
             // Replace to point to your project or solution
-            string projectPath = @"c:\development\jerriep\dotnet-outdated\DotNetOutdated.sln";
+            if (args.Length < 1) {
+              throw new ArgumentException("must provide a solution file to operate on");
+            }
+            var solutionFile = new FileInfo(args[0]);
+            if (solutionFile.Exists == false) {
+              throw new ArgumentException($"cannot find {solutionFile.FullName}");
+            }
+
+            string projectPath = solutionFile.FullName;
 
             var dependencyGraphService = new DependencyGraphService();
             var dependencyGraph = dependencyGraphService.GenerateDependencyGraph(projectPath);


### PR DESCRIPTION
I found this tool (and the related blog post https://www.jerriepelser.com/blog/analyze-dotnet-project-dependencies-part-2/) very helpful in tracking down some odd binding errors I was getting in a .NET Core 3.1 project which had been downgraded to .NET Core 2.2 and was still somehow referencing a transitive dependency on a .NET Core 3.1 library.

while using it I would offer two small improvements:
- [x] promote the hard-coded solution file name to a required CLI arg;
- [x] add some defensive null checking to avoid bailing partway through the report on a `NullReferenceException`